### PR TITLE
Add Thor task for console export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v4.2.0 (Xxx 2022)
+  - Add Thor task for console export.
+  - Add view hook for Export#index
+
 v4.1.0 (November 2021)
   - No changes
 

--- a/app/views/dradis/plugins/pdf_export/export/_index-content.html.erb
+++ b/app/views/dradis/plugins/pdf_export/export/_index-content.html.erb
@@ -1,0 +1,13 @@
+<%= content_tag :div, id: 'plugin-pdf_export', class: 'tab-pane fade' do %>
+
+  <h4>Generate a custom PDF report</h4>
+
+  To customize the PDF structure, see the <a href="https://dradisframework.com/support/guides/reporting/pdf_reports.html" target="_blank">Creating PDF reports</a> guide.
+
+  <%= form_tag project_export_manager_path(current_project), target: '_blank' do %>
+    <%= hidden_field_tag :plugin, :pdf_export %>
+    <%= hidden_field_tag :route, :root %>
+
+    <button id="export-button" class="btn btn-lg btn-primary mt-4">Export</button>
+  <% end %>
+<% end%>

--- a/app/views/dradis/plugins/pdf_export/export/_index-tabs.html.erb
+++ b/app/views/dradis/plugins/pdf_export/export/_index-tabs.html.erb
@@ -1,0 +1,3 @@
+<li class='nav-item'>
+  <a href='#pdf_export' class='nav-link' data-toggle='tab' data-target='#plugin-pdf_export'><i class="fa fa-file-pdf-o"></i> Custom PDF reports</a>
+</li>

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -1,0 +1,46 @@
+class PdfExportTasks < Thor
+  include Rails.application.config.dradis.thor_helper_module
+
+  namespace     "dradis:plugins:pdf"
+
+  desc 'export', 'export the current repository structure as PDF document'
+  method_option :output,   required: false, type: :string, desc: "the report file to create (if ends in .pdf), or directory to create it in"
+  # method_option :template, required: true, type: :string, desc: "the template file to use. If not provided the value of the 'advanced_word_export:docx' setting will be used."
+
+  def export
+    require 'config/environment'
+
+    # The options we'll end up passing to the Processor class
+    opts = {}
+
+    report_path = options.output || Rails.root
+    unless report_path.to_s =~ /\.pdf\z/
+      date = DateTime.now.strftime("%Y-%m-%d")
+      base_filename = "dradis-report_#{date}.pdf"
+
+      report_filename = NamingService.name_file(
+        original_filename: base_filename,
+        pathname: Pathname.new(report_path)
+      )
+
+      report_path = File.join(report_path, report_filename)
+    end
+
+    # if template = options.template
+    #   shell.error("Template file doesn't exist") && exit(1) unless File.exists?(template)
+    #   task_options[:template] = template
+    # end
+
+    detect_and_set_project_scope
+
+    exporter = Dradis::Plugins::PdfExport::Exporter.new(task_options)
+    pdf = exporter.export
+
+    File.open(report_path, 'wb') do |f|
+      f << pdf.render
+    end
+
+    logger.info{ "Report file created at:\n\t#{report_path}" }
+  end
+
+end

--- a/lib/tasks/thorfile.rb
+++ b/lib/tasks/thorfile.rb
@@ -5,7 +5,6 @@ class PdfExportTasks < Thor
 
   desc 'export', 'export the current repository structure as PDF document'
   method_option :output,   required: false, type: :string, desc: "the report file to create (if ends in .pdf), or directory to create it in"
-  # method_option :template, required: true, type: :string, desc: "the template file to use. If not provided the value of the 'advanced_word_export:docx' setting will be used."
 
   def export
     require 'config/environment'
@@ -25,11 +24,6 @@ class PdfExportTasks < Thor
 
       report_path = File.join(report_path, report_filename)
     end
-
-    # if template = options.template
-    #   shell.error("Template file doesn't exist") && exit(1) unless File.exists?(template)
-    #   task_options[:template] = template
-    # end
 
     detect_and_set_project_scope
 


### PR DESCRIPTION
Before this PR the PDF exporter didn't come with a Thor console task for generating the report.

The PR also adds the hook for the in-app export view.